### PR TITLE
Structurize plaintext

### DIFF
--- a/daemons/pacemakerd/pacemaker.service.in
+++ b/daemons/pacemakerd/pacemaker.service.in
@@ -73,6 +73,14 @@ SendSIGKILL=no
 #
 # ExecStopPost=/bin/sh -c 'pidof pacemaker-controld || killall -TERM corosync'
 
+# Pacemaker will restart along with Corosync if Corosync is stopped while
+# Pacemaker is running.
+# In this case, if you want to be fenced always (if you do not want to restart)
+# uncomment ExecStopPost below.
+# 
+# ExecStopPost=/bin/sh -c 'pidof corosync || \
+#              /usr/bin/systemctl --no-block stop pacemaker'
+
 # When the service functions properly, it will wait to exit until all resources
 # have been stopped on the local node, and potentially across all nodes that
 # are shutting down.  The default of 30min should cover most typical cluster

--- a/include/crm/common/output.h
+++ b/include/crm/common/output.h
@@ -21,6 +21,7 @@ extern "C" {
 
 #  include <stdio.h>
 #  include <libxml/tree.h>
+#  include <libxml/HTMLparser.h>
 
 #  include <glib.h>
 #  include <crm/common/results.h>
@@ -111,6 +112,7 @@ typedef struct pcmk__message_entry_s {
  */
 pcmk__output_t *pcmk__mk_text_output(char **argv);
 pcmk__output_t *pcmk__mk_xml_output(char **argv);
+pcmk__output_t *pcmk__mk_html_output(char **argv);
 
 /*!
  * \brief This structure contains everything that makes up a single output
@@ -338,6 +340,38 @@ struct pcmk__output_s {
      * \param[in,out] out The output functions structure.
      */
     void (*end_list) (pcmk__output_t *out);
+
+    /*!
+     * \internal
+     * \brief Set a string attribute to the last added item (eg. tag).
+     *
+     * \param[in,out] out The output functions structure.
+     */
+    void (*set_str_prop) (pcmk__output_t *out, const char *id, const char *value);
+
+    /*!
+     * \internal
+     * \brief Set an integer attribute to the last added item (eg. tag).
+     *
+     * \param[in,out] out The output functions structure.
+     */
+    void (*set_int_prop) (pcmk__output_t *out, const char *id, int value);
+
+    /*!
+     * \internal
+     * \brief Set a float attribute to the last added item (eg. tag).
+     *
+     * \param[in,out] out The output functions structure.
+     */
+    void (*set_float_prop) (pcmk__output_t *out, const char *id, double value);
+
+    /*!
+     * \internal
+     * \brief Set a boolean attribute to the last added item (eg. tag).
+     *
+     * \param[in,out] out The output functions structure.
+     */
+    void (*set_bool_prop) (pcmk__output_t *out, const char *id, int condition);
 };
 
 /*!

--- a/include/crm/common/util.h
+++ b/include/crm/common/util.h
@@ -65,6 +65,12 @@ crm_itoa(int an_int)
     return crm_strdup_printf("%d", an_int);
 }
 
+static inline char *
+crm_ftoa(double a_float)
+{
+    return crm_strdup_printf("%f", a_float);
+}
+
 /*!
  * \brief Create hash table with dynamically allocated string keys/values
  *

--- a/include/crm/pengine/internal.h
+++ b/include/crm/pengine/internal.h
@@ -97,11 +97,11 @@ gboolean group_active(resource_t * rsc, gboolean all);
 gboolean clone_active(resource_t * rsc, gboolean all);
 gboolean pe__bundle_active(pe_resource_t *rsc, gboolean all);
 
-void native_print(resource_t * rsc, const char *pre_text, long options, void *print_data);
-void group_print(resource_t * rsc, const char *pre_text, long options, void *print_data);
-void clone_print(resource_t * rsc, const char *pre_text, long options, void *print_data);
+void native_print(resource_t * rsc, const char *pre_text, long options, void *print_data, pcmk__output_t* out);
+void group_print(resource_t * rsc, const char *pre_text, long options, void *print_data, pcmk__output_t* out);
+void clone_print(resource_t * rsc, const char *pre_text, long options, void *print_data, pcmk__output_t* out);
 void pe__print_bundle(pe_resource_t *rsc, const char *pre_text, long options,
-                      void *print_data);
+                      void *print_data, pcmk__output_t* out);
 
 void native_free(resource_t * rsc);
 void group_free(resource_t * rsc);
@@ -173,9 +173,10 @@ extern gboolean order_actions(action_t * lh_action, action_t * rh_action, enum p
 GHashTable *node_hash_dup(GHashTable * hash);
 
 /* Printing functions for debug */
-extern void print_node(const char *pre_text, node_t * node, gboolean details);
+extern void print_node(const char *pre_text, node_t * node, gboolean details, pcmk__output_t *out);
 
-extern void print_resource(int log_level, const char *pre_text, resource_t * rsc, gboolean details);
+extern void print_resource(int log_level, const char *pre_text, resource_t * rsc, gboolean details
+		           , pcmk__output_t *out);
 
 extern void dump_node_scores_worker(int level, const char *file, const char *function, int line,
                                     resource_t * rsc, const char *comment, GHashTable * nodes);
@@ -340,7 +341,8 @@ void pe_fence_node(pe_working_set_t * data_set, node_t * node, const char *reaso
 node_t *pe_create_node(const char *id, const char *uname, const char *type,
                        const char *score, pe_working_set_t * data_set);
 bool remote_id_conflict(const char *remote_name, pe_working_set_t *data);
-void common_print(resource_t * rsc, const char *pre_text, const char *name, node_t *node, long options, void *print_data);
+void common_print(resource_t * rsc, const char *pre_text, const char *name, node_t *node
+                  , long options, void *print_data, pcmk__output_t *out);
 pe_resource_t *pe__find_bundle_replica(const pe_resource_t *bundle,
                                        const pe_node_t *node);
 bool pe__bundle_needs_remote_name(pe_resource_t *rsc);

--- a/include/crm/pengine/pe_types.h
+++ b/include/crm/pengine/pe_types.h
@@ -25,6 +25,7 @@ extern "C" {
 #  include <crm/crm.h>              // GListPtr
 #  include <crm/common/iso8601.h>
 #  include <crm/pengine/common.h>
+#  include <crm/common/output.h>
 
 typedef struct pe_node_s pe_node_t;
 typedef struct pe_action_s pe_action_t;
@@ -46,7 +47,7 @@ typedef struct resource_object_functions_s {
     /* parameter result must be free'd */
     char *(*parameter) (pe_resource_t*, pe_node_t*, gboolean, const char*,
                         pe_working_set_t*);
-    void (*print) (pe_resource_t*, const char*, long, void*);
+    void (*print) (pe_resource_t*, const char*, long, void*, pcmk__output_t*);
     gboolean (*active) (pe_resource_t*, gboolean);
     enum rsc_role_e (*state) (const pe_resource_t*, gboolean);
     pe_node_t *(*location) (const pe_resource_t*, GList**, int);

--- a/lib/common/Makefile.am
+++ b/lib/common/Makefile.am
@@ -50,6 +50,7 @@ libcrmcommon_la_SOURCES	+= operations.c
 libcrmcommon_la_SOURCES	+= output.c
 libcrmcommon_la_SOURCES	+= output_text.c
 libcrmcommon_la_SOURCES	+= output_xml.c
+libcrmcommon_la_SOURCES	+= output_html.c
 libcrmcommon_la_SOURCES	+= pid.c
 libcrmcommon_la_SOURCES	+= procfs.c
 libcrmcommon_la_SOURCES	+= remote.c

--- a/lib/common/output_html.c
+++ b/lib/common/output_html.c
@@ -1,0 +1,253 @@
+/*
+ * Copyright 2019 the Pacemaker project contributors
+ *
+ * The version control history for this file may have further details.
+ *
+ * This source code is licensed under the GNU Lesser General Public License
+ * version 2.1 or later (LGPLv2.1+) WITHOUT ANY WARRANTY.
+ */
+
+#ifndef _GNU_SOURCE
+#  define _GNU_SOURCE
+#endif
+
+#include <ctype.h>
+#include <stdarg.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <crm/crm.h>
+#include <crm/common/output.h>
+#include <crm/common/xml.h>
+
+typedef struct html_private_s {
+    xmlNode *root;
+    GQueue *parent_q;
+} html_private_t;
+
+static void
+html_free_priv(pcmk__output_t *out) {
+    html_private_t *priv = out->priv;
+
+    if (priv == NULL) {
+        return;
+    }
+
+    xmlFreeNode(priv->root);
+    g_queue_free(priv->parent_q);
+    free(priv);
+}
+
+static bool
+html_init(pcmk__output_t *out) {
+    html_private_t *priv = NULL;
+
+    /* If html_init was previously called on this output struct, just return. */
+    if (out->priv != NULL) {
+        return true;
+    } else {
+        out->priv = calloc(1, sizeof(html_private_t));
+        if (out->priv == NULL) {
+            return false;
+        }
+
+        priv = out->priv;
+    }
+
+    priv->root = create_xml_node(NULL, "html");
+
+    priv->parent_q = g_queue_new();
+    g_queue_push_tail(priv->parent_q, priv->root);
+
+    return true;
+}
+
+static void
+html_reset(pcmk__output_t *out) {
+    char *buf = NULL;
+    html_private_t *priv = out->priv;
+
+    CRM_ASSERT(priv != NULL);
+
+    buf = dump_xml_formatted_with_text(priv->root);
+    fprintf(out->dest, "%s", buf);
+
+    free(buf);
+    html_free_priv(out);
+    html_init(out);
+}
+
+static void
+html_subprocess_output(pcmk__output_t *out, int exit_status,
+                      const char *proc_stdout, const char *proc_stderr) {
+    htmlNodePtr node, child_node;
+    char *rc_as_str = NULL;
+    html_private_t *priv = out->priv;
+    CRM_ASSERT(priv != NULL);
+
+    rc_as_str = crm_itoa(exit_status);
+
+    node = xmlNewNode(g_queue_peek_tail(priv->parent_q), (pcmkXmlStr) "command");
+    xmlSetProp(node, (pcmkXmlStr) "code", (pcmkXmlStr) rc_as_str);
+
+    if (proc_stdout != NULL) {
+        child_node = xmlNewTextChild(node, NULL, (pcmkXmlStr) "output",
+                                     (pcmkXmlStr) proc_stdout);
+        xmlSetProp(child_node, (pcmkXmlStr) "source", (pcmkXmlStr) "stdout");
+    }
+
+    if (proc_stderr != NULL) {
+        child_node = xmlNewTextChild(node, NULL, (pcmkXmlStr) "output",
+                                     (pcmkXmlStr) proc_stderr);
+        xmlSetProp(node, (pcmkXmlStr) "source", (pcmkXmlStr) "stderr");
+    }
+
+    pcmk__xml_add_node(out, node);
+    free(rc_as_str);
+}
+
+G_GNUC_PRINTF(2, 3)
+static void
+html_info(pcmk__output_t *out, const char *format, ...) {
+    /* This function intentially left blank */
+}
+
+static void
+html_output_xml(pcmk__output_t *out, const char *name, const char *buf) {
+    htmlNodePtr parent = NULL;
+    htmlNodePtr cdata_node = NULL;
+    html_private_t *priv = out->priv;
+
+    CRM_ASSERT(priv != NULL);
+
+    parent = xmlNewChild(g_queue_peek_tail(priv->parent_q), NULL,
+                         (pcmkXmlStr) name, NULL);
+    cdata_node = xmlNewCDataBlock(getDocPtr(parent), (pcmkXmlStr) buf, strlen(buf));
+    xmlAddChild(parent, cdata_node);
+}
+
+static void
+html_begin_list(pcmk__output_t *out, const char *name,
+               const char *singular_noun, const char *plural_noun) {
+    htmlNodePtr list_node = NULL;
+    html_private_t *priv = out->priv;
+
+    CRM_ASSERT(priv != NULL);
+
+    list_node = create_xml_node(g_queue_peek_tail(priv->parent_q), name);
+    g_queue_push_tail(priv->parent_q, list_node);
+}
+
+static void
+html_list_item(pcmk__output_t *out, const char *name, const char *content) {
+    html_private_t *priv = out->priv;
+    
+    CRM_ASSERT(priv != NULL);
+
+    if (name == NULL) {
+        htmlNodePtr node = g_queue_peek_tail(priv->parent_q);
+        xmlNodeAddContent(node, (pcmkXmlStr) " ");
+        xmlNodeAddContent(node, (pcmkXmlStr) content);
+    }
+    xmlNewChild(g_queue_peek_tail(priv->parent_q), NULL,
+                (pcmkXmlStr) name, (pcmkXmlStr) content);
+}
+
+static void
+html_end_list(pcmk__output_t *out) {
+    html_private_t *priv = out->priv;
+
+    CRM_ASSERT(priv != NULL);
+    g_queue_pop_tail(priv->parent_q);
+}
+
+static void
+html_set_str_prop(pcmk__output_t *out, const char *id, const char *value)
+{
+    html_private_t *priv = out->priv;
+    htmlNodePtr xml_node = g_queue_peek_tail(priv->parent_q);
+    if (xml_node->children)
+        xml_node = xmlGetLastChild(xml_node);
+    xmlSetProp(xml_node, (pcmkXmlStr) id, (pcmkXmlStr) (value ? value : ""));
+}
+
+static void
+html_set_int_prop(pcmk__output_t *out, const char *id, int value)
+{
+    char *str = crm_itoa(value);
+    html_set_str_prop(out, id, str);
+    free(str);
+}
+
+static void
+html_set_float_prop(pcmk__output_t *out, const char *id, double value)
+{
+    char *str = crm_ftoa(value);
+    html_set_str_prop(out, id, str);
+    free(str);
+}
+
+static void
+html_set_bool_prop(pcmk__output_t *out, const char *id, int condition)
+{
+    html_set_str_prop(out, id, condition ? "true" : "false");
+}
+
+static void
+html_finish(pcmk__output_t *out, crm_exit_t exit_status) {
+    char *rc_as_str = NULL;
+    char *buf = NULL;
+    html_private_t *priv = out->priv;
+
+    /* If root is NULL, html_init failed and we are being called from pcmk__output_free
+     * in the pcmk__output_new path.
+     */
+    if (priv->root == NULL) {
+        return;
+    }
+
+    rc_as_str = crm_itoa(exit_status);
+
+    html_list_item(out, "meta", NULL);
+    html_set_str_prop(out, "status", crm_exit_str(exit_status));
+
+    buf = dump_xml_formatted_with_text(priv->root);
+    fprintf(out->dest, "%s", buf);
+
+    free(rc_as_str);
+    free(buf);
+}
+
+pcmk__output_t *
+pcmk__mk_html_output(char **argv) {
+    pcmk__output_t *retval = calloc(1, sizeof(pcmk__output_t));
+
+    if (retval == NULL) {
+        return NULL;
+    }
+
+    retval->request = g_strjoinv(" ", argv);
+    retval->supports_quiet = false;
+
+    retval->init = html_init;
+    retval->free_priv = html_free_priv;
+    retval->finish = html_finish;
+    retval->reset = html_reset;
+
+    retval->register_message = pcmk__register_message;
+    retval->message = pcmk__call_message;
+
+    retval->subprocess_output = html_subprocess_output;
+    retval->info = html_info;
+    retval->output_xml = html_output_xml;
+
+    retval->begin_list = html_begin_list;
+    retval->list_item = html_list_item;
+    retval->end_list = html_end_list;
+
+    retval->set_str_prop = html_set_str_prop;
+    retval->set_int_prop = html_set_int_prop;
+    retval->set_float_prop = html_set_float_prop;
+    retval->set_bool_prop = html_set_bool_prop;
+
+    return retval;
+}

--- a/lib/common/output_xml.c
+++ b/lib/common/output_xml.c
@@ -196,6 +196,38 @@ xml_end_list(pcmk__output_t *out) {
     free(buf);
 }
 
+static void
+xml_set_str_prop(pcmk__output_t *out, const char *id, const char *value)
+{
+    xml_private_t *priv = out->priv;
+    xmlNodePtr xml_node = g_queue_peek_tail(priv->parent_q);
+    if (xml_node->children)
+        xml_node = xmlGetLastChild(xml_node);
+    xmlSetProp(xml_node, (pcmkXmlStr) id, (pcmkXmlStr) (value ? value : ""));
+}
+
+static void
+xml_set_int_prop(pcmk__output_t *out, const char *id, int value)
+{
+    char *str = crm_itoa(value);
+    xml_set_str_prop(out, id, str);
+    free(str);
+}
+
+static void
+xml_set_float_prop(pcmk__output_t *out, const char *id, double value)
+{
+    char *str = crm_ftoa(value);
+    xml_set_str_prop(out, id, str);
+    free(str);
+}
+
+static void
+xml_set_bool_prop(pcmk__output_t *out, const char *id, int condition)
+{
+    xml_set_str_prop(out, id, condition ? "true" : "false");
+}
+
 pcmk__output_t *
 pcmk__mk_xml_output(char **argv) {
     pcmk__output_t *retval = calloc(1, sizeof(pcmk__output_t));
@@ -222,6 +254,11 @@ pcmk__mk_xml_output(char **argv) {
     retval->begin_list = xml_begin_list;
     retval->list_item = xml_list_item;
     retval->end_list = xml_end_list;
+
+    retval->set_str_prop = xml_set_str_prop;
+    retval->set_int_prop = xml_set_int_prop;
+    retval->set_float_prop = xml_set_float_prop;
+    retval->set_bool_prop = xml_set_bool_prop;
 
     return retval;
 }

--- a/lib/pacemaker/pcmk_sched_group.c
+++ b/lib/pacemaker/pcmk_sched_group.c
@@ -332,7 +332,7 @@ group_rsc_colocation_rh(pe_resource_t *rsc_lh, pe_resource_t *rsc_rh,
     CRM_CHECK(rsc_lh->variant == pe_native, return);
 
     pe_rsc_trace(rsc_rh, "Processing RH of constraint %s", constraint->id);
-    print_resource(LOG_TRACE, "LHS", rsc_lh, TRUE);
+    print_resource(LOG_TRACE, "LHS", rsc_lh, TRUE, NULL);
 
     if (is_set(rsc_rh->flags, pe_rsc_provisional)) {
         return;

--- a/lib/pacemaker/pcmk_sched_messages.c
+++ b/lib/pacemaker/pcmk_sched_messages.c
@@ -70,7 +70,7 @@ pcmk__schedule_actions(pe_working_set_t *data_set, xmlNode *xml_input,
             if (is_set(rsc->flags, pe_rsc_orphan) && rsc->role == RSC_ROLE_STOPPED) {
                 continue;
             }
-            rsc->fns->print(rsc, NULL, pe_print_log, &rsc_log_level);
+            rsc->fns->print(rsc, NULL, pe_print_log, &rsc_log_level, NULL);
         }
     }
 

--- a/lib/pacemaker/pcmk_sched_native.c
+++ b/lib/pacemaker/pcmk_sched_native.c
@@ -456,7 +456,7 @@ native_color(resource_t * rsc, node_t * prefer, pe_working_set_t * data_set)
     }
 
     set_bit(rsc->flags, pe_rsc_allocating);
-    print_resource(alloc_details, "Allocating: ", rsc, FALSE);
+    print_resource(alloc_details, "Allocating: ", rsc, FALSE, NULL);
     dump_node_scores(alloc_details, rsc, "Pre-alloc", rsc->allowed_nodes);
 
     for (gIter = rsc->rsc_cons; gIter != NULL; gIter = gIter->next) {
@@ -497,7 +497,7 @@ native_color(resource_t * rsc, node_t * prefer, pe_working_set_t * data_set)
                                                     pe_weights_rollback);
     }
 
-    print_resource(LOG_TRACE, "Allocating: ", rsc, FALSE);
+    print_resource(LOG_TRACE, "Allocating: ", rsc, FALSE, NULL);
     if (rsc->next_role == RSC_ROLE_STOPPED) {
         pe_rsc_trace(rsc, "Making sure %s doesn't get allocated", rsc->id);
         /* make sure it doesn't come up again */
@@ -559,7 +559,7 @@ native_color(resource_t * rsc, node_t * prefer, pe_working_set_t * data_set)
     }
 
     clear_bit(rsc->flags, pe_rsc_allocating);
-    print_resource(LOG_TRACE, "Allocated ", rsc, TRUE);
+    print_resource(LOG_TRACE, "Allocated ", rsc, TRUE, NULL);
 
     if (rsc->is_remote_node) {
         node_t *remote_node = pe_find_node(data_set->nodes, rsc->id);

--- a/lib/pengine/bundle.c
+++ b/lib/pengine/bundle.c
@@ -1427,7 +1427,7 @@ print_rsc_in_list(resource_t *rsc, const char *pre_text, long options,
         if (options & pe_print_html) {
             status_print("<li>");
         }
-        rsc->fns->print(rsc, pre_text, options, print_data);
+        rsc->fns->print(rsc, pre_text, options, print_data, NULL);
         if (options & pe_print_html) {
             status_print("</li>\n");
         }
@@ -1514,12 +1514,12 @@ print_bundle_replica(pe__bundle_replica_t *replica, const char *pre_text,
     }
 
     node = pe__current_node(replica->container);
-    common_print(rsc, pre_text, buffer, node, options, print_data);
+    common_print(rsc, pre_text, buffer, node, options, print_data, NULL);
 }
 
 void
 pe__print_bundle(pe_resource_t *rsc, const char *pre_text, long options,
-                 void *print_data)
+                 void *print_data, pcmk__output_t* out)
 {
     pe__bundle_variant_data_t *bundle_data = NULL;
     char *child_text = NULL;

--- a/lib/pengine/clone.c
+++ b/lib/pengine/clone.c
@@ -98,7 +98,7 @@ pe__create_clone_child(pe_resource_t *rsc, pe_working_set_t *data_set)
 
     add_hash_param(child_rsc->meta, XML_RSC_ATTR_INCARNATION_MAX, inc_max);
 
-    print_resource(LOG_TRACE, "Added ", child_rsc, FALSE);
+    print_resource(LOG_TRACE, "Added ", child_rsc, FALSE, NULL);
 
   bail:
     free(inc_num);
@@ -326,7 +326,7 @@ clone_print_xml(resource_t * rsc, const char *pre_text, long options, void *prin
     for (; gIter != NULL; gIter = gIter->next) {
         resource_t *child_rsc = (resource_t *) gIter->data;
 
-        child_rsc->fns->print(child_rsc, child_text, options, print_data);
+        child_rsc->fns->print(child_rsc, child_text, options, print_data, NULL);
     }
 
     status_print("%s</clone>\n", pre_text);
@@ -364,7 +364,7 @@ bool is_set_recursive(resource_t * rsc, long long flag, bool any)
 }
 
 void
-clone_print(resource_t * rsc, const char *pre_text, long options, void *print_data)
+clone_print(resource_t * rsc, const char *pre_text, long options, void *print_data, pcmk__output_t* out)
 {
     char *list_text = NULL;
     char *child_text = NULL;
@@ -474,7 +474,7 @@ clone_print(resource_t * rsc, const char *pre_text, long options, void *print_da
             if (options & pe_print_html) {
                 status_print("<li>\n");
             }
-            child_rsc->fns->print(child_rsc, child_text, options, print_data);
+            child_rsc->fns->print(child_rsc, child_text, options, print_data, out);
             if (options & pe_print_html) {
                 status_print("</li>\n");
             }

--- a/lib/pengine/group.c
+++ b/lib/pengine/group.c
@@ -66,7 +66,7 @@ group_unpack(resource_t * rsc, pe_working_set_t * data_set)
                 group_data->first_child = new_rsc;
             }
             group_data->last_child = new_rsc;
-            print_resource(LOG_TRACE, "Added ", new_rsc, FALSE);
+            print_resource(LOG_TRACE, "Added ", new_rsc, FALSE, NULL);
         }
     }
 
@@ -124,7 +124,7 @@ group_print_xml(resource_t * rsc, const char *pre_text, long options, void *prin
     for (; gIter != NULL; gIter = gIter->next) {
         resource_t *child_rsc = (resource_t *) gIter->data;
 
-        child_rsc->fns->print(child_rsc, child_text, options, print_data);
+        child_rsc->fns->print(child_rsc, child_text, options, print_data, NULL);
     }
 
     status_print("%s</group>\n", pre_text);
@@ -132,7 +132,7 @@ group_print_xml(resource_t * rsc, const char *pre_text, long options, void *prin
 }
 
 void
-group_print(resource_t * rsc, const char *pre_text, long options, void *print_data)
+group_print(resource_t * rsc, const char *pre_text, long options, void *print_data, pcmk__output_t* out)
 {
     char *child_text = NULL;
     GListPtr gIter = rsc->children;
@@ -167,7 +167,7 @@ group_print(resource_t * rsc, const char *pre_text, long options, void *print_da
             if (options & pe_print_html) {
                 status_print("<li>\n");
             }
-            child_rsc->fns->print(child_rsc, child_text, options, print_data);
+            child_rsc->fns->print(child_rsc, child_text, options, print_data, out);
             if (options & pe_print_html) {
                 status_print("</li>\n");
             }

--- a/lib/pengine/native.c
+++ b/lib/pengine/native.c
@@ -333,6 +333,7 @@ native_active(resource_t * rsc, gboolean all)
 struct print_data_s {
     long options;
     void *print_data;
+    pcmk__output_t *out;
 };
 
 static void
@@ -340,8 +341,15 @@ native_print_attr(gpointer key, gpointer value, gpointer user_data)
 {
     long options = ((struct print_data_s *)user_data)->options;
     void *print_data = ((struct print_data_s *)user_data)->print_data;
+    pcmk__output_t *out = ((struct print_data_s *)user_data)->out;
+    char buffer[LINE_MAX];
 
-    status_print("Option: %s = %s\n", (char *)key, (char *)value);
+    snprintf(buffer, LINE_MAX,  "Option: %s = %s\n", (char *)key, (char *)value);
+    if (out) {
+        out->list_item(out, NULL, buffer);
+    } else {
+        status_print("%s", buffer);
+    }
 }
 
 static const char *
@@ -422,7 +430,7 @@ native_displayable_state(resource_t *rsc, long options)
 }
 
 static void
-native_print_xml(resource_t * rsc, const char *pre_text, long options, void *print_data)
+native_print_xml(resource_t * rsc, const char *pre_text, long options, void *print_data, pcmk__output_t* out)
 {
     const char *class = crm_element_value(rsc->xml, XML_AGENT_ATTR_CLASS);
     const char *prov = crm_element_value(rsc->xml, XML_AGENT_ATTR_PROVIDER);
@@ -430,62 +438,118 @@ native_print_xml(resource_t * rsc, const char *pre_text, long options, void *pri
     const char *target_role = NULL;
 
     /* resource information. */
-    status_print("%s<resource ", pre_text);
-    status_print("id=\"%s\" ", rsc_printable_id(rsc));
-    status_print("resource_agent=\"%s%s%s:%s\" ",
-                 class,
-                 prov ? "::" : "", prov ? prov : "", crm_element_value(rsc->xml, XML_ATTR_TYPE));
-
-    status_print("role=\"%s\" ", rsc_state);
-    if (rsc->meta) {
-        target_role = g_hash_table_lookup(rsc->meta, XML_RSC_ATTR_TARGET_ROLE);
-    }
-    if (target_role) {
-        status_print("target_role=\"%s\" ", target_role);
-    }
-    status_print("active=\"%s\" ", rsc->fns->active(rsc, TRUE) ? "true" : "false");
-    status_print("orphaned=\"%s\" ", is_set(rsc->flags, pe_rsc_orphan) ? "true" : "false");
-    status_print("blocked=\"%s\" ", is_set(rsc->flags, pe_rsc_block) ? "true" : "false");
-    status_print("managed=\"%s\" ", is_set(rsc->flags, pe_rsc_managed) ? "true" : "false");
-    status_print("failed=\"%s\" ", is_set(rsc->flags, pe_rsc_failed) ? "true" : "false");
-    status_print("failure_ignored=\"%s\" ",
-                 is_set(rsc->flags, pe_rsc_failure_ignored) ? "true" : "false");
-    status_print("nodes_running_on=\"%d\" ", g_list_length(rsc->running_on));
-
-    if (options & pe_print_pending) {
-        const char *pending_task = native_pending_task(rsc);
-
-        if (pending_task) {
-            status_print("pending=\"%s\" ", pending_task);
+    if (out) {
+        char ra_name[70];
+        out->begin_list(out, "resource", NULL, NULL);
+        out->set_str_prop(out, "id", rsc_printable_id(rsc));
+        sprintf(ra_name, "%s%s%s:%s", class, prov ? "::" : "", prov ? prov : ""
+            , crm_element_value(rsc->xml, XML_ATTR_TYPE));
+        out->set_str_prop(out, "resource_agent", ra_name);
+        out->set_str_prop(out, "role", rsc_state);
+        if (rsc->meta) {
+            target_role = g_hash_table_lookup(rsc->meta, XML_RSC_ATTR_TARGET_ROLE);
         }
-    }
-
-    if (options & pe_print_dev) {
-        status_print("provisional=\"%s\" ",
-                     is_set(rsc->flags, pe_rsc_provisional) ? "true" : "false");
-        status_print("runnable=\"%s\" ", is_set(rsc->flags, pe_rsc_runnable) ? "true" : "false");
-        status_print("priority=\"%f\" ", (double)rsc->priority);
-        status_print("variant=\"%s\" ", crm_element_name(rsc->xml));
-    }
-
-    /* print out the nodes this resource is running on */
-    if (options & pe_print_rsconly) {
-        status_print("/>\n");
-        /* do nothing */
-    } else if (rsc->running_on != NULL) {
-        GListPtr gIter = rsc->running_on;
-
-        status_print(">\n");
-        for (; gIter != NULL; gIter = gIter->next) {
-            node_t *node = (node_t *) gIter->data;
-
-            status_print("%s    <node name=\"%s\" id=\"%s\" cached=\"%s\"/>\n", pre_text,
-                         node->details->uname, node->details->id,
-                         node->details->online ? "false" : "true");
+        if (target_role) {
+            out->set_str_prop(out, "target_role", target_role);
         }
-        status_print("%s</resource>\n", pre_text);
+        out->set_bool_prop(out, "active ", rsc->fns->active(rsc, TRUE));
+        out->set_bool_prop(out, "orphaned", is_set(rsc->flags, pe_rsc_orphan));
+        out->set_bool_prop(out, "blocked", is_set(rsc->flags, pe_rsc_block));
+        out->set_bool_prop(out, "managed", is_set(rsc->flags, pe_rsc_managed));
+        out->set_bool_prop(out, "failed", is_set(rsc->flags, pe_rsc_failed));
+        out->set_bool_prop(out, "failure_ignored", is_set(rsc->flags, pe_rsc_failure_ignored));
+        out->set_int_prop(out, "nodes_running_on", g_list_length(rsc->running_on));
+
+        if (options & pe_print_pending) {
+            const char *pending_task = native_pending_task(rsc);
+
+            if (pending_task) {
+                out->set_str_prop(out, "pending", pending_task);
+            }
+        }
+
+        if (options & pe_print_dev) {
+            out->set_bool_prop(out, "provisional", is_set(rsc->flags, pe_rsc_provisional));
+            out->set_bool_prop(out, "runnable", is_set(rsc->flags, pe_rsc_runnable));
+            out->set_float_prop(out, "priority", (double)rsc->priority);
+            out->set_str_prop(out, "variant", crm_element_name(rsc->xml));
+        }
+
+        /* print out the nodes this resource is running on */
+        if (options & pe_print_rsconly) {
+            /* do nothing */
+        } else if (rsc->running_on != NULL) {
+            GListPtr gIter = rsc->running_on;
+
+            for (; gIter != NULL; gIter = gIter->next) {
+                node_t *node = (node_t *) gIter->data;
+
+                out->list_item(out, "node", NULL);
+                out->set_str_prop(out, "node_name", node->details->uname);
+                out->set_str_prop(out, "id", node->details->id);
+                out->set_bool_prop(out, "cached", node->details->online);
+            }
+        }
+
+        out->end_list(out);
     } else {
-        status_print("/>\n");
+        status_print("%s<resource ", pre_text);
+        status_print("id=\"%s\" ", rsc_printable_id(rsc));
+        status_print("resource_agent=\"%s%s%s:%s\" ",
+                     class,
+                     prov ? "::" : "", prov ? prov : "", crm_element_value(rsc->xml, XML_ATTR_TYPE));
+
+        status_print("role=\"%s\" ", rsc_state);
+        if (rsc->meta) {
+            target_role = g_hash_table_lookup(rsc->meta, XML_RSC_ATTR_TARGET_ROLE);
+        }
+        if (target_role) {
+            status_print("target_role=\"%s\" ", target_role);
+        }
+        status_print("active=\"%s\" ", rsc->fns->active(rsc, TRUE) ? "true" : "false");
+        status_print("orphaned=\"%s\" ", is_set(rsc->flags, pe_rsc_orphan) ? "true" : "false");
+        status_print("blocked=\"%s\" ", is_set(rsc->flags, pe_rsc_block) ? "true" : "false");
+        status_print("managed=\"%s\" ", is_set(rsc->flags, pe_rsc_managed) ? "true" : "false");
+        status_print("failed=\"%s\" ", is_set(rsc->flags, pe_rsc_failed) ? "true" : "false");
+        status_print("failure_ignored=\"%s\" ",
+                     is_set(rsc->flags, pe_rsc_failure_ignored) ? "true" : "false");
+        status_print("nodes_running_on=\"%d\" ", g_list_length(rsc->running_on));
+
+        if (options & pe_print_pending) {
+            const char *pending_task = native_pending_task(rsc);
+
+            if (pending_task) {
+                status_print("pending=\"%s\" ", pending_task);
+            }
+        }
+
+        if (options & pe_print_dev) {
+            status_print("provisional=\"%s\" ",
+                         is_set(rsc->flags, pe_rsc_provisional) ? "true" : "false");
+            status_print("runnable=\"%s\" ", is_set(rsc->flags, pe_rsc_runnable) ? "true" : "false");
+            status_print("priority=\"%f\" ", (double)rsc->priority);
+            status_print("variant=\"%s\" ", crm_element_name(rsc->xml));
+        }
+
+        /* print out the nodes this resource is running on */
+        if (options & pe_print_rsconly) {
+            status_print("/>\n");
+            /* do nothing */
+        } else if (rsc->running_on != NULL) {
+            GListPtr gIter = rsc->running_on;
+
+            status_print(">\n");
+            for (; gIter != NULL; gIter = gIter->next) {
+                node_t *node = (node_t *) gIter->data;
+
+                status_print("%s    <node name=\"%s\" id=\"%s\" cached=\"%s\"/>\n", pre_text,
+                             node->details->uname, node->details->id,
+                             node->details->online ? "false" : "true");
+            }
+            status_print("%s</resource>\n", pre_text);
+        } else {
+            status_print("/>\n");
+        }
     }
 }
 
@@ -499,7 +563,8 @@ comma_if(int i)
 }
 
 void
-common_print(resource_t * rsc, const char *pre_text, const char *name, node_t *node, long options, void *print_data)
+common_print(resource_t * rsc, const char *pre_text, const char *name, node_t *node, long options
+             , void *print_data, pcmk__output_t *out)
 {
     const char *desc = NULL;
     const char *class = crm_element_value(rsc->xml, XML_AGENT_ATTR_CLASS);
@@ -510,6 +575,7 @@ common_print(resource_t * rsc, const char *pre_text, const char *name, node_t *n
     int offset = 0;
     int flagOffset = 0;
     char buffer[LINE_MAX];
+    char buffer2[LINE_MAX];
     char flagBuffer[LINE_MAX];
 
     CRM_ASSERT(rsc->variant == pe_native);
@@ -529,7 +595,7 @@ common_print(resource_t * rsc, const char *pre_text, const char *name, node_t *n
     }
 
     if (options & pe_print_xml) {
-        native_print_xml(rsc, pre_text, options, print_data);
+        native_print_xml(rsc, pre_text, options, print_data, out);
         return;
     }
 
@@ -537,24 +603,53 @@ common_print(resource_t * rsc, const char *pre_text, const char *name, node_t *n
         node = NULL;
     }
 
-    if (options & pe_print_html) {
-        if (is_not_set(rsc->flags, pe_rsc_managed)) {
-            status_print("<font color=\"yellow\">");
+    if (out) {
+        if (options & pe_print_html) {
+            if (is_not_set(rsc->flags, pe_rsc_managed)) {
+                out->begin_list(out, "font", NULL, NULL);
+                out->set_str_prop(out, "color", "yellow");
 
-        } else if (is_set(rsc->flags, pe_rsc_failed)) {
-            status_print("<font color=\"red\">");
+            } else if (is_set(rsc->flags, pe_rsc_failed)) {
+                out->begin_list(out, "font", NULL, NULL);
+                out->set_str_prop(out, "color", "red");
 
-        } else if (rsc->variant == pe_native && (rsc->running_on == NULL)) {
-            status_print("<font color=\"red\">");
+            } else if (rsc->variant == pe_native && (rsc->running_on == NULL)) {
+                out->begin_list(out, "font", NULL, NULL);
+                out->set_str_prop(out, "color", "red");
 
-        } else if (g_list_length(rsc->running_on) > 1) {
-            status_print("<font color=\"orange\">");
+            } else if (g_list_length(rsc->running_on) > 1) {
+                out->begin_list(out, "font", NULL, NULL);
+                out->set_str_prop(out, "color", "orange");
 
-        } else if (is_set(rsc->flags, pe_rsc_failure_ignored)) {
-            status_print("<font color=\"yellow\">");
+            } else if (is_set(rsc->flags, pe_rsc_failure_ignored)) {
+                out->begin_list(out, "font", NULL, NULL);
+                out->set_str_prop(out, "color", "yellow");
 
-        } else {
-            status_print("<font color=\"green\">");
+            } else {
+                out->begin_list(out, "font", NULL, NULL);
+                out->set_str_prop(out, "color", "green");
+            }
+        }
+    } else {
+        if (options & pe_print_html) {
+            if (is_not_set(rsc->flags, pe_rsc_managed)) {
+                status_print("<font color=\"yellow\">");
+
+            } else if (is_set(rsc->flags, pe_rsc_failed)) {
+                status_print("<font color=\"red\">");
+
+            } else if (rsc->variant == pe_native && (rsc->running_on == NULL)) {
+                status_print("<font color=\"red\">");
+
+            } else if (g_list_length(rsc->running_on) > 1) {
+                status_print("<font color=\"orange\">");
+
+            } else if (is_set(rsc->flags, pe_rsc_failure_ignored)) {
+                status_print("<font color=\"yellow\">");
+
+            } else {
+                status_print("<font color=\"green\">");
+            }
         }
     }
 
@@ -639,9 +734,14 @@ common_print(resource_t * rsc, const char *pre_text, const char *name, node_t *n
 
     CRM_LOG_ASSERT(offset > 0);
     if(flagOffset > 0) {
-        status_print("%s (%s)%s%s", buffer, flagBuffer, desc?" ":"", desc?desc:"");
+        sprintf(buffer2, "%s (%s)%s%s", buffer, flagBuffer, desc?" ":"", desc?desc:"");
     } else {
-        status_print("%s%s%s", buffer, desc?" ":"", desc?desc:"");
+        sprintf(buffer2, "%s%s%s", buffer, desc?" ":"", desc?desc:"");
+    }
+    if (out) {    
+        out->list_item(out, NULL, buffer2);
+    } else {
+        status_print("%s", buffer2);
     }
 
 #if CURSES_ENABLED
@@ -655,7 +755,11 @@ common_print(resource_t * rsc, const char *pre_text, const char *name, node_t *n
 #endif
 
     if (options & pe_print_html) {
-        status_print(" </font> ");
+        if (out) {
+            out->end_list(out);
+        } else {
+            status_print(" </font> ");
+        }
     }
 
     if ((options & pe_print_rsconly)) {
@@ -665,7 +769,11 @@ common_print(resource_t * rsc, const char *pre_text, const char *name, node_t *n
         int counter = 0;
 
         if (options & pe_print_html) {
-            status_print("<ul>\n");
+            if (out) {
+                out->begin_list(out, "ul", NULL, NULL);
+            } else {
+                status_print("<ul>\n");
+            }
         } else if ((options & pe_print_printf)
                    || (options & pe_print_ncurses)) {
             status_print("[");
@@ -677,26 +785,51 @@ common_print(resource_t * rsc, const char *pre_text, const char *name, node_t *n
             counter++;
 
             if (options & pe_print_html) {
-                status_print("<li>\n%s", n->details->uname);
+                if (out) {
+                    out->begin_list(out, "li", NULL, NULL);
+                } else {
+                    status_print("<li>\n%s", n->details->uname);
+                }
 
             } else if ((options & pe_print_printf)
                        || (options & pe_print_ncurses)) {
-                status_print(" %s", n->details->uname);
+                if (out) {
+                    out->list_item(out, NULL, n->details->uname);
+                } else {
+                    status_print(" %s", n->details->uname);
+                }
 
             } else if ((options & pe_print_log)) {
-                status_print("\t%d : %s", counter, n->details->uname);
+                if (out) {
+                    sprintf(buffer, "\t%d : %s", counter, n->details->uname);
+                    out->list_item(out, NULL, buffer);
+                } else {
+                    status_print("\t%d : %s", counter, n->details->uname);
+                }
 
             } else {
-                status_print("%s", n->details->uname);
+                if (out) {
+                    out->list_item(out, NULL, n->details->uname);
+                } else {
+                    status_print("%s", n->details->uname);
+                }
             }
             if (options & pe_print_html) {
-                status_print("</li>\n");
+                if (out) {
+                    out->end_list(out);
+                } else {
+                    status_print("</li>\n");
+                }
 
             }
         }
 
         if (options & pe_print_html) {
-            status_print("</ul>\n");
+            if (out) {
+                out->end_list(out);
+            } else {
+                status_print("</ul>\n");
+            }
         } else if ((options & pe_print_printf)
                    || (options & pe_print_ncurses)) {
             status_print(" ]");
@@ -704,7 +837,11 @@ common_print(resource_t * rsc, const char *pre_text, const char *name, node_t *n
     }
 
     if (options & pe_print_html) {
-        status_print("<br/>\n");
+        if (out) {
+            out->list_item(out, "br", NULL);
+        } else {
+            status_print("<br/>\n");
+        }
     } else if (options & pe_print_suppres_nl) {
         /* nothing */
     } else if ((options & pe_print_printf) || (options & pe_print_ncurses)) {
@@ -716,6 +853,7 @@ common_print(resource_t * rsc, const char *pre_text, const char *name, node_t *n
 
         pdata.options = options;
         pdata.print_data = print_data;
+        pdata.out = out;
         g_hash_table_foreach(rsc->parameters, native_print_attr, &pdata);
     }
 
@@ -723,14 +861,21 @@ common_print(resource_t * rsc, const char *pre_text, const char *name, node_t *n
         GHashTableIter iter;
         node_t *n = NULL;
 
-        status_print("%s\t(%s%svariant=%s, priority=%f)", pre_text,
+        offset = snprintf(buffer, LINE_MAX - offset, "%s\t(%s%svariant=%s, priority=%f)",
+                     pre_text,
                      is_set(rsc->flags, pe_rsc_provisional) ? "provisional, " : "",
                      is_set(rsc->flags, pe_rsc_runnable) ? "" : "non-startable, ",
                      crm_element_name(rsc->xml), (double)rsc->priority);
-        status_print("%s\tAllowed Nodes", pre_text);
+        offset += snprintf(buffer, LINE_MAX - offset, "%s\tAllowed Nodes", pre_text);
         g_hash_table_iter_init(&iter, rsc->allowed_nodes);
         while (g_hash_table_iter_next(&iter, NULL, (void **)&n)) {
-            status_print("%s\t * %s %d", pre_text, n->details->uname, n->weight);
+            offset += snprintf(buffer, LINE_MAX - offset, "%s\t * %s %d", pre_text, n->details->uname, n->weight);
+        }
+        
+        if (out) {
+            out->list_item(out, NULL, buffer);
+        } else {
+            status_print("%s", buffer);
         }
     }
 
@@ -738,22 +883,27 @@ common_print(resource_t * rsc, const char *pre_text, const char *name, node_t *n
         GHashTableIter iter;
         node_t *n = NULL;
 
-        status_print("%s\t=== Allowed Nodes\n", pre_text);
+        snprintf(buffer, LINE_MAX, "%s\t=== Allowed Nodes\n", pre_text);
+        if (out) {
+            out->list_item(out, NULL, buffer);
+        } else {
+            status_print("%s", buffer);
+        }
         g_hash_table_iter_init(&iter, rsc->allowed_nodes);
         while (g_hash_table_iter_next(&iter, NULL, (void **)&n)) {
-            print_node("\t", n, FALSE);
+            print_node("\t", n, FALSE, out);
         }
     }
 }
 
 void
-native_print(resource_t * rsc, const char *pre_text, long options, void *print_data)
+native_print(resource_t * rsc, const char *pre_text, long options, void *print_data, pcmk__output_t* out)
 {
     node_t *node = NULL;
 
     CRM_ASSERT(rsc->variant == pe_native);
     if (options & pe_print_xml) {
-        native_print_xml(rsc, pre_text, options, print_data);
+        native_print_xml(rsc, pre_text, options, print_data, out);
         return;
     }
 
@@ -764,7 +914,7 @@ native_print(resource_t * rsc, const char *pre_text, long options, void *print_d
         node = rsc->pending_node;
     }
 
-    common_print(rsc, pre_text, rsc_printable_id(rsc), node, options, print_data);
+    common_print(rsc, pre_text, rsc_printable_id(rsc), node, options, print_data, out);
 }
 
 void

--- a/lib/pengine/unpack.c
+++ b/lib/pengine/unpack.c
@@ -671,7 +671,7 @@ link_rsc2remotenode(pe_working_set_t *data_set, resource_t *new_rsc)
         return;
     }
 
-    print_resource(LOG_TRACE, "Linking remote-node connection resource, ", new_rsc, FALSE);
+    print_resource(LOG_TRACE, "Linking remote-node connection resource, ", new_rsc, FALSE, NULL);
 
     remote_node = pe_find_node(data_set->nodes, new_rsc->id);
     CRM_CHECK(remote_node != NULL, return;);
@@ -744,7 +744,7 @@ unpack_resources(xmlNode * xml_resources, pe_working_set_t * data_set)
         crm_trace("Beginning unpack... <%s id=%s... >", crm_element_name(xml_obj), ID(xml_obj));
         if (common_unpack(xml_obj, &new_rsc, NULL, data_set)) {
             data_set->resources = g_list_append(data_set->resources, new_rsc);
-            print_resource(LOG_TRACE, "Added ", new_rsc, FALSE);
+            print_resource(LOG_TRACE, "Added ", new_rsc, FALSE, NULL);
 
         } else {
             crm_config_err("Failed unpacking %s %s",
@@ -1816,7 +1816,7 @@ process_orphan_resource(xmlNode * rsc_entry, node_t * node, pe_working_set_t * d
         clear_bit(rsc->flags, pe_rsc_managed);
 
     } else {
-        print_resource(LOG_TRACE, "Added orphan", rsc, FALSE);
+        print_resource(LOG_TRACE, "Added orphan", rsc, FALSE, NULL);
 
         CRM_CHECK(rsc != NULL, return NULL);
         resource_location(rsc, NULL, -INFINITY, "__orphan_dont_run__", data_set);

--- a/lib/pengine/utils.c
+++ b/lib/pengine/utils.c
@@ -1250,7 +1250,7 @@ find_rsc_op_entry(resource_t * rsc, const char *key)
 }
 
 void
-print_node(const char *pre_text, node_t * node, gboolean details)
+print_node(const char *pre_text, node_t * node, gboolean details, pcmk__output_t *out)
 {
     if (node == NULL) {
         crm_trace("%s%s: <NULL>", pre_text == NULL ? "" : pre_text, pre_text == NULL ? "" : ": ");
@@ -1277,7 +1277,7 @@ print_node(const char *pre_text, node_t * node, gboolean details)
         for (; gIter != NULL; gIter = gIter->next) {
             resource_t *rsc = (resource_t *) gIter->data;
 
-            print_resource(LOG_TRACE, "\t\t", rsc, FALSE);
+            print_resource(LOG_TRACE, "\t\t", rsc, FALSE, out);
         }
     }
 }
@@ -1294,7 +1294,8 @@ print_str_str(gpointer key, gpointer value, gpointer user_data)
 }
 
 void
-print_resource(int log_level, const char *pre_text, resource_t * rsc, gboolean details)
+print_resource(int log_level, const char *pre_text, resource_t * rsc, gboolean details
+               , pcmk__output_t *out)
 {
     long options = pe_print_log | pe_print_pending;
 
@@ -1306,7 +1307,7 @@ print_resource(int log_level, const char *pre_text, resource_t * rsc, gboolean d
     if (details) {
         options |= pe_print_details;
     }
-    rsc->fns->print(rsc, pre_text, options, &log_level);
+    rsc->fns->print(rsc, pre_text, options, &log_level, out);
 }
 
 void

--- a/tools/crm_resource_print.c
+++ b/tools/crm_resource_print.c
@@ -114,7 +114,7 @@ cli_resource_print_list(pe_working_set_t * data_set, bool raw)
             && rsc->fns->active(rsc, TRUE) == FALSE) {
             continue;
         }
-        rsc->fns->print(rsc, NULL, opts, stdout);
+        rsc->fns->print(rsc, NULL, opts, stdout, NULL);
         found++;
     }
 
@@ -146,7 +146,7 @@ cli_resource_print_operations(const char *rsc_id, const char *host_uname, bool a
 
         rsc = pe_find_resource(data_set->resources, op_rsc);
         if(rsc) {
-            rsc->fns->print(rsc, "", opts, stdout);
+            rsc->fns->print(rsc, "", opts, stdout, NULL);
         } else {
             fprintf(stdout, "Unknown resource %s", op_rsc);
         }
@@ -263,7 +263,7 @@ cli_resource_print(resource_t *rsc, pe_working_set_t *data_set, bool expanded)
     char *rsc_xml = NULL;
     int opts = pe_print_printf | pe_print_pending;
 
-    rsc->fns->print(rsc, NULL, opts, stdout);
+    rsc->fns->print(rsc, NULL, opts, stdout, NULL);
 
     rsc_xml = dump_xml_formatted((!expanded && rsc->orig_xml)?
                                  rsc->orig_xml : rsc->xml);

--- a/tools/crm_simulate.c
+++ b/tools/crm_simulate.c
@@ -189,7 +189,7 @@ print_cluster_status(pe_working_set_t * data_set, long options)
             && rsc->role == RSC_ROLE_STOPPED) {
             continue;
         }
-        rsc->fns->print(rsc, NULL, pe_print_printf | options, stdout);
+        rsc->fns->print(rsc, NULL, pe_print_printf | options, stdout, NULL);
     }
     fprintf(stdout, "\n");
 }

--- a/tools/stonith_admin.c
+++ b/tools/stonith_admin.c
@@ -51,7 +51,7 @@ static struct crm_option long_options[] = {
         "\tBe less descriptive in output."
     },
     {   "cleanup", no_argument, NULL, 'c',
-        "\tCleanup wherever appropriate."
+        "\tCleanup wherever appropriate. Requires: --history."
     },
     {   "broadcast", no_argument, NULL, 'b',
         "Broadcast wherever appropriate."


### PR DESCRIPTION
Please review the code and leave your comments.

The ultimate goal is to structurize any plaintext output into the pcmk__output_t structure and then return the text in the required format. This PR is only the first step. It structurizes only the xml output of crm_mon given in plaintext. If the refactored functions are called from the print_xml_status function, they  store the result into the pcmk__output_t, otherwise they work as before - they print it into the stdout.